### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Nightwatch.js Dockerfile
 #
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN apk --no-cache add \
     # Install NodeJS and NPM:
@@ -20,13 +20,6 @@ RUN apk --no-cache add \
   && rm -rf \
     /tmp/* \
     /root/.npm
-
-# Add node system user/group with uid/gid 1000.
-# This is a workaround for boot2docker issue #581, see
-# https://github.com/boot2docker/boot2docker/issues/581
-RUN adduser -D -u 1000 node
-
-USER node
 
 WORKDIR /home/node
 


### PR DESCRIPTION
- Bump up Alpine's version to latest stable.
- Drop boot2docker workaround since it's in maintenance mode and we advocate for Docker for Mac https://github.com/allthings/devenv/blob/master/docs/requirements.md#docker--docker-compose.